### PR TITLE
We should set ID attribute when serialize the response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /composer.lock
 /vendor/
 /.phpunit.result.cache
+/.idea
+/.vscode

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "php": ">=7.4",
         "robrichards/xmlseclibs": "~2.0|~3.0|~4.0",
         "symfony/http-foundation": "~5.0|~6.0",
-        "psr/event-dispatcher": "^1.0"
+        "psr/event-dispatcher": "^1.0",
+        "ext-dom": "*"
     },
     "require-dev": {
         "symfony/dom-crawler": "~5.0",

--- a/src/LightSaml/Model/Protocol/Response.php
+++ b/src/LightSaml/Model/Protocol/Response.php
@@ -11,6 +11,7 @@
 
 namespace LightSaml\Model\Protocol;
 
+use LightSaml\Helper;
 use LightSaml\Model\Assertion\Assertion;
 use LightSaml\Model\Assertion\EncryptedElement;
 use LightSaml\Model\Context\DeserializationContext;
@@ -129,6 +130,10 @@ class Response extends StatusResponse
 
     public function serialize(\DOMNode $parent, SerializationContext $context)
     {
+        if ($this->getID() === null) {
+            $this->setID(Helper::generateID());
+        }
+
         $result = $this->createElement('samlp:Response', SamlConstants::NS_PROTOCOL, $parent, $context);
 
         parent::serialize($result, $context);


### PR DESCRIPTION
Thank you for you create this repo I think this repo is the most concise in all SAML libraries written in PHP.
I am considering using this repo in my development, then I found some point that maybe will be convenient for other developers whose using the repo in their SSO development.