### PR TITLE
Fix deprecated Serializable interface for PHP 8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
-## 0.0.2 (2022-12-23)
-
-## 0.0.1 (2022-12-23)
-
 ## 4.1.1 (2022-12-21)
 
 ### Code Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## 0.0.1 (2022-12-23)
+
 ## 4.1.1 (2022-12-21)
 
 ### Code Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## 0.0.3 (2022-12-30)
+
 ## 4.1.1 (2022-12-21)
 
 ### Code Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## 0.0.2 (2022-12-23)
+
 ## 0.0.1 (2022-12-23)
 
 ## 4.1.1 (2022-12-21)

--- a/src/Meta/ParameterBag.php
+++ b/src/Meta/ParameterBag.php
@@ -113,13 +113,29 @@ class ParameterBag implements \IteratorAggregate, \Countable, \Serializable
         return count($this->parameters);
     }
 
-    public function serialize()
+    /**
+     * @deprecated Since php 8.1. Use __serialize() instead
+     */
+    public function serialize(): string
     {
-        return serialize($this->parameters);
+        return serialize($this->__serialize());
     }
 
+    public function __serialize(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @deprecated Since php 8.1. Use __unserialize() instead
+     */
     public function unserialize($serialized)
     {
-        $this->parameters = unserialize($serialized);
+        $this->__unserialize(unserialize($serialized));
+    }
+
+    public function __unserialize(array $serialized)
+    {
+        $this->parameters = $serialized;
     }
 }


### PR DESCRIPTION
Hello,
Here is a fix to remove the deprecated on the serialize interface for PHP 8.1
```Deprecated: LightSaml\Meta\ParameterBag implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) at /var/www/html/vendor/litesaml/lightsaml/src/LightSaml/Meta/ParameterBag.php:14```

* https://php.watch/versions/8.1/serializable-deprecated