### PR TITLE
Allow override session

### DIFF
--- a/src/Error/LightSamlSessionNotFoundException.php
+++ b/src/Error/LightSamlSessionNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LightSaml\Error;
+
+class LightSamlSessionNotFoundException extends LightSamlException
+{
+}

--- a/src/Store/Request/RequestStateSessionStore.php
+++ b/src/Store/Request/RequestStateSessionStore.php
@@ -2,11 +2,12 @@
 
 namespace LightSaml\Store\Request;
 
+use LightSaml\Error\LightSamlSessionNotFoundException;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class RequestStateSessionStore extends AbstractRequestStateArrayStore
 {
-    /** @var \Symfony\Component\HttpFoundation\Session\SessionInterface */
+    /** @var null|SessionInterface */
     protected $session;
 
     /** @var string */
@@ -19,7 +20,7 @@ class RequestStateSessionStore extends AbstractRequestStateArrayStore
      * @param string $providerId
      * @param string $prefix
      */
-    public function __construct(SessionInterface $session, $providerId, $prefix = 'saml_request_state_')
+    public function __construct(?SessionInterface $session, $providerId, $prefix = 'saml_request_state_')
     {
         $this->session = $session;
         $this->providerId = $providerId;
@@ -34,16 +35,25 @@ class RequestStateSessionStore extends AbstractRequestStateArrayStore
         return sprintf('%s_%s', $this->providerId, $this->prefix);
     }
 
+    protected function getSession(): SessionInterface
+    {
+        if (null !== $this->session) {
+            return $this->session;
+        }
+
+        throw new LightSamlSessionNotFoundException('Session Not Found');
+    }
+
     /**
      * @return array
      */
     protected function getArray()
     {
-        return $this->session->get($this->getKey(), []);
+        return $this->getSession()->get($this->getKey(), []);
     }
 
     protected function setArray(array $arr)
     {
-        $this->session->set($this->getKey(), $arr);
+        $this->getSession()->set($this->getKey(), $arr);
     }
 }


### PR DESCRIPTION
In Symfony context, it's not recommended to access session with the dependency injection (https://symfony.com/blog/new-in-symfony-5-3-session-service-deprecation).
To be able to continue to use the stores as services, we need a way to retrieve the session at runtime.
With this PR, we can extend the stores and redefine the way we want to handle the session.