### PR TITLE
fix: Always use `random_bytes()` in `Helper::generateRandomBytes()`

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -87,16 +87,7 @@ final class Helper
             throw new \InvalidArgumentException();
         }
 
-        if (function_exists('openssl_random_pseudo_bytes')) {
-            return openssl_random_pseudo_bytes($length);
-        }
-
-        $data = '';
-        for ($i = 0; $i < $length; ++$i) {
-            $data .= chr(mt_rand(0, 255));
-        }
-
-        return $data;
+        return random_bytes($length);
     }
 
     /**


### PR DESCRIPTION
As PHP 7.4 is the minimally required PHP version, `random_bytes()` is guaranteed to exist. It is the recommended interface to obtain secure randomness.

This change is a fix, because previously the function performed a fallback to insecure randomness if OpenSSL is not available.