### PR TITLE
'errcontext' param has been removed from set_error_handler callback i…

### DIFF
--- a/src/Validator/Model/Xsd/XsdValidator.php
+++ b/src/Validator/Model/Xsd/XsdValidator.php
@@ -38,7 +38,7 @@ class XsdValidator
         libxml_clear_errors();
         $doc = new \DOMDocument();
 
-        set_error_handler(function ($errno, $errstr, $errfile, $errline, array $errcontext) use (&$result) {
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$result) {
             $error = new XsdError(XsdError::FATAL, $errno, $errstr, 0, 0);
             $result[] = $error;
         });


### PR DESCRIPTION
…n PHP8