### PR TITLE
fix(php): remove implicitly nullable parameter declarations

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
 
     steps:
       - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
 /vendor/
 /.phpunit.result.cache
+/.idea/

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">./src</directory>

--- a/src/Binding/AbstractBinding.php
+++ b/src/Binding/AbstractBinding.php
@@ -16,7 +16,7 @@ abstract class AbstractBinding
     /**
      * @return AbstractBinding
      */
-    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher = null)
+    public function setEventDispatcher(?EventDispatcherInterface $eventDispatcher = null)
     {
         $this->eventDispatcher = $eventDispatcher;
 

--- a/src/Binding/BindingFactory.php
+++ b/src/Binding/BindingFactory.php
@@ -15,7 +15,7 @@ class BindingFactory implements BindingFactoryInterface
     /**
      * @param EventDispatcherInterface $eventDispatcher
      */
-    public function __construct(EventDispatcherInterface $eventDispatcher = null)
+    public function __construct(?EventDispatcherInterface $eventDispatcher = null)
     {
         $this->eventDispatcher = $eventDispatcher;
     }
@@ -23,7 +23,7 @@ class BindingFactory implements BindingFactoryInterface
     /**
      * @return BindingFactoryInterface
      */
-    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher = null)
+    public function setEventDispatcher(?EventDispatcherInterface $eventDispatcher = null)
     {
         $this->eventDispatcher = $eventDispatcher;
 

--- a/src/Binding/HttpRedirectBinding.php
+++ b/src/Binding/HttpRedirectBinding.php
@@ -194,7 +194,7 @@ class HttpRedirectBinding extends AbstractBinding
     /**
      * @param string $msg
      */
-    protected function addSignatureToUrl(&$msg, SignatureWriter $signature = null)
+    protected function addSignatureToUrl(&$msg, ?SignatureWriter $signature = null)
     {
         /** @var $key XMLSecurityKey */
         $key = $signature ? $signature->getXmlSecurityKey() : null;

--- a/src/Bridge/Pimple/Container/Factory/OwnContainerProvider.php
+++ b/src/Bridge/Pimple/Container/Factory/OwnContainerProvider.php
@@ -20,7 +20,7 @@ class OwnContainerProvider implements ServiceProviderInterface
     /**
      * @param CredentialInterface[] $ownCredentials
      */
-    public function __construct(EntityDescriptorProviderInterface $ownEntityDescriptorProvider, array $ownCredentials = null)
+    public function __construct(EntityDescriptorProviderInterface $ownEntityDescriptorProvider, ?array $ownCredentials = null)
     {
         $this->ownEntityDescriptorProvider = $ownEntityDescriptorProvider;
         if ($ownCredentials) {

--- a/src/Bridge/Pimple/Container/Factory/SystemContainerProvider.php
+++ b/src/Bridge/Pimple/Container/Factory/SystemContainerProvider.php
@@ -20,7 +20,7 @@ class SystemContainerProvider implements ServiceProviderInterface
     /** @var EventDispatcherInterface|null */
     private $eventDispatcher;
 
-    public function __construct($mockSession = false, EventDispatcherInterface $eventDispatcher = null)
+    public function __construct($mockSession = false, ?EventDispatcherInterface $eventDispatcher = null)
     {
         $this->mockSession = $mockSession;
         $this->eventDispatcher = $eventDispatcher;

--- a/src/Context/AbstractContext.php
+++ b/src/Context/AbstractContext.php
@@ -33,7 +33,7 @@ abstract class AbstractContext implements ContextInterface
     /**
      * @return ContextInterface
      */
-    public function setParent(ContextInterface $parent = null)
+    public function setParent(?ContextInterface $parent = null)
     {
         $this->parent = $parent;
 

--- a/src/Context/ContextInterface.php
+++ b/src/Context/ContextInterface.php
@@ -17,7 +17,7 @@ interface ContextInterface extends \IteratorAggregate
     /**
      * @return ContextInterface
      */
-    public function setParent(ContextInterface $parent = null);
+    public function setParent(?ContextInterface $parent = null);
 
     /**
      * @param string      $name

--- a/src/Context/Profile/AssertionContext.php
+++ b/src/Context/Profile/AssertionContext.php
@@ -49,7 +49,7 @@ class AssertionContext extends AbstractProfileContext
      *
      * @return AssertionContext
      */
-    public function setAssertion(Assertion $assertion = null)
+    public function setAssertion(?Assertion $assertion = null)
     {
         $this->assertion = $assertion;
 
@@ -69,7 +69,7 @@ class AssertionContext extends AbstractProfileContext
      *
      * @return AssertionContext
      */
-    public function setEncryptedAssertion(EncryptedElement $encryptedAssertion = null)
+    public function setEncryptedAssertion(?EncryptedElement $encryptedAssertion = null)
     {
         $this->encryptedAssertion = $encryptedAssertion;
 

--- a/src/Context/Profile/ExceptionContext.php
+++ b/src/Context/Profile/ExceptionContext.php
@@ -10,7 +10,7 @@ class ExceptionContext extends AbstractProfileContext
     /** @var ExceptionContext|null */
     protected $nextExceptionContext;
 
-    public function __construct(\Exception $exception = null)
+    public function __construct(?\Exception $exception = null)
     {
         $this->exception = $exception;
     }

--- a/src/Context/Profile/Helper/LogHelper.php
+++ b/src/Context/Profile/Helper/LogHelper.php
@@ -13,7 +13,7 @@ abstract class LogHelper
      *
      * @return array
      */
-    public static function getActionContext(ContextInterface $context, ActionInterface $action, array $extraData = null)
+    public static function getActionContext(ContextInterface $context, ActionInterface $action, ?array $extraData = null)
     {
         return self::getContext($context, $action, $extraData, false);
     }
@@ -23,7 +23,7 @@ abstract class LogHelper
      *
      * @return array
      */
-    public static function getActionErrorContext(ContextInterface $context, ActionInterface $action, array $extraData = null)
+    public static function getActionErrorContext(ContextInterface $context, ActionInterface $action, ?array $extraData = null)
     {
         return self::getContext($context, $action, $extraData, true);
     }
@@ -35,7 +35,7 @@ abstract class LogHelper
      *
      * @return array
      */
-    private static function getContext(ContextInterface $context, ActionInterface $action = null, array $extraData = null, $logWholeContext = false)
+    private static function getContext(ContextInterface $context, ?ActionInterface $action = null, ?array $extraData = null, $logWholeContext = false)
     {
         $topContext = $context->getTopParent();
         $result = [];

--- a/src/Context/Profile/MessageContext.php
+++ b/src/Context/Profile/MessageContext.php
@@ -49,7 +49,7 @@ class MessageContext extends AbstractProfileContext
     /**
      * @return MessageContext
      */
-    public function setMessage(SamlMessage $message = null)
+    public function setMessage(?SamlMessage $message = null)
     {
         $this->message = $message;
 

--- a/src/Credential/X509Credential.php
+++ b/src/Credential/X509Credential.php
@@ -12,7 +12,7 @@ class X509Credential extends AbstractCredential implements X509CredentialInterfa
     /**
      * @param XMLSecurityKey $privateKey
      */
-    public function __construct(X509Certificate $certificate, XMLSecurityKey $privateKey = null)
+    public function __construct(X509Certificate $certificate, ?XMLSecurityKey $privateKey = null)
     {
         parent::__construct();
         $this->certificate = $certificate;

--- a/src/Error/LightSamlAuthenticationException.php
+++ b/src/Error/LightSamlAuthenticationException.php
@@ -14,7 +14,7 @@ class LightSamlAuthenticationException extends LightSamlValidationException
      * @param int        $code
      * @param \Exception $previous
      */
-    public function __construct(StatusResponse $response, $message = '', $code = 0, \Exception $previous = null)
+    public function __construct(StatusResponse $response, $message = '', $code = 0, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Error/LightSamlContextException.php
+++ b/src/Error/LightSamlContextException.php
@@ -14,7 +14,7 @@ class LightSamlContextException extends LightSamlException
      * @param int        $code
      * @param \Exception $previous
      */
-    public function __construct(ContextInterface $context, $message = '', $code = 0, \Exception $previous = null)
+    public function __construct(ContextInterface $context, $message = '', $code = 0, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Meta/SigningOptions.php
+++ b/src/Meta/SigningOptions.php
@@ -26,7 +26,7 @@ class SigningOptions
      * @param XMLSecurityKey  $privateKey
      * @param X509Certificate $certificate
      */
-    public function __construct(XMLSecurityKey $privateKey = null, X509Certificate $certificate = null)
+    public function __construct(?XMLSecurityKey $privateKey = null, ?X509Certificate $certificate = null)
     {
         $this->enabled = true;
         $this->privateKey = $privateKey;
@@ -47,7 +47,7 @@ class SigningOptions
      *
      * @return SigningOptions
      */
-    public function setCertificate(X509Certificate $certificate = null)
+    public function setCertificate(?X509Certificate $certificate = null)
     {
         $this->certificate = $certificate;
 
@@ -67,7 +67,7 @@ class SigningOptions
      *
      * @return SigningOptions
      */
-    public function setPrivateKey(XMLSecurityKey $privateKey = null)
+    public function setPrivateKey(?XMLSecurityKey $privateKey = null)
     {
         $this->privateKey = $privateKey;
 

--- a/src/Model/Assertion/Assertion.php
+++ b/src/Model/Assertion/Assertion.php
@@ -128,7 +128,7 @@ class Assertion extends AbstractSamlModel
     /**
      * @return Assertion
      */
-    public function setConditions(Conditions $conditions = null)
+    public function setConditions(?Conditions $conditions = null)
     {
         $this->conditions = $conditions;
 
@@ -214,7 +214,7 @@ class Assertion extends AbstractSamlModel
      *
      * @return Assertion
      */
-    public function setIssuer(Issuer $issuer = null)
+    public function setIssuer(?Issuer $issuer = null)
     {
         $this->issuer = $issuer;
 
@@ -234,7 +234,7 @@ class Assertion extends AbstractSamlModel
      *
      * @return Assertion
      */
-    public function setSignature(Signature $signature = null)
+    public function setSignature(?Signature $signature = null)
     {
         $this->signature = $signature;
 

--- a/src/Model/Assertion/ProxyRestriction.php
+++ b/src/Model/Assertion/ProxyRestriction.php
@@ -22,7 +22,7 @@ class ProxyRestriction extends AbstractCondition
      * @param int      $count
      * @param string[] $audience
      */
-    public function __construct($count = null, array $audience = null)
+    public function __construct($count = null, ?array $audience = null)
     {
         $this->count = $count;
         $this->audience = $audience;

--- a/src/Model/Assertion/Subject.php
+++ b/src/Model/Assertion/Subject.php
@@ -20,7 +20,7 @@ class Subject extends AbstractSamlModel
      *
      * @return Subject
      */
-    public function setNameID(NameID $nameId = null)
+    public function setNameID(?NameID $nameId = null)
     {
         $this->nameId = $nameId;
 

--- a/src/Model/Assertion/SubjectConfirmation.php
+++ b/src/Model/Assertion/SubjectConfirmation.php
@@ -44,7 +44,7 @@ class SubjectConfirmation extends AbstractSamlModel
     /**
      * @return SubjectConfirmation
      */
-    public function setEncryptedId(EncryptedElement $encryptedId = null)
+    public function setEncryptedId(?EncryptedElement $encryptedId = null)
     {
         $this->encryptedId = $encryptedId;
 
@@ -62,7 +62,7 @@ class SubjectConfirmation extends AbstractSamlModel
     /**
      * @return SubjectConfirmation
      */
-    public function setNameID(NameID $nameId = null)
+    public function setNameID(?NameID $nameId = null)
     {
         $this->nameId = $nameId;
 
@@ -80,7 +80,7 @@ class SubjectConfirmation extends AbstractSamlModel
     /**
      * @return SubjectConfirmation
      */
-    public function setSubjectConfirmationData(SubjectConfirmationData $subjectConfirmationData = null)
+    public function setSubjectConfirmationData(?SubjectConfirmationData $subjectConfirmationData = null)
     {
         $this->subjectConfirmationData = $subjectConfirmationData;
 

--- a/src/Model/Context/DeserializationContext.php
+++ b/src/Model/Context/DeserializationContext.php
@@ -16,7 +16,7 @@ class DeserializationContext
     /**
      * @param \DOMDocument $document
      */
-    public function __construct(\DOMDocument $document = null)
+    public function __construct(?\DOMDocument $document = null)
     {
         $this->document = $document ? $document : new \DOMDocument();
     }
@@ -32,7 +32,7 @@ class DeserializationContext
     /**
      * @return DeserializationContext
      */
-    public function setDocument(\DOMDocument $document)
+    public function setDocument(?\DOMDocument $document)
     {
         $this->document = $document;
 

--- a/src/Model/Context/SerializationContext.php
+++ b/src/Model/Context/SerializationContext.php
@@ -10,7 +10,7 @@ class SerializationContext
     /**
      * @param \DOMDocument $document
      */
-    public function __construct(\DOMDocument $document = null)
+    public function __construct(?\DOMDocument $document = null)
     {
         $this->document = $document ? $document : new \DOMDocument();
     }

--- a/src/Model/Metadata/KeyDescriptor.php
+++ b/src/Model/Metadata/KeyDescriptor.php
@@ -23,7 +23,7 @@ class KeyDescriptor extends AbstractSamlModel
     /**
      * @param string|null $use
      */
-    public function __construct($use = null, X509Certificate $certificate = null)
+    public function __construct($use = null, ?X509Certificate $certificate = null)
     {
         $this->use = $use;
         $this->certificate = $certificate;

--- a/src/Model/Protocol/SamlMessage.php
+++ b/src/Model/Protocol/SamlMessage.php
@@ -200,7 +200,7 @@ abstract class SamlMessage extends AbstractSamlModel
     /**
      * @return SamlMessage
      */
-    public function setIssuer(Issuer $issuer = null)
+    public function setIssuer(?Issuer $issuer = null)
     {
         $this->issuer = $issuer;
 
@@ -238,7 +238,7 @@ abstract class SamlMessage extends AbstractSamlModel
     /**
      * @return SamlMessage
      */
-    public function setSignature(Signature $signature = null)
+    public function setSignature(?Signature $signature = null)
     {
         $this->signature = $signature;
 

--- a/src/Model/Protocol/Status.php
+++ b/src/Model/Protocol/Status.php
@@ -18,7 +18,7 @@ class Status extends AbstractSamlModel
     /**
      * @param string $message
      */
-    public function __construct(StatusCode $statusCode = null, $message = null)
+    public function __construct(?StatusCode $statusCode = null, $message = null)
     {
         $this->statusCode = $statusCode;
         $this->statusMessage = $message;

--- a/src/Model/XmlDSig/SignatureWriter.php
+++ b/src/Model/XmlDSig/SignatureWriter.php
@@ -50,7 +50,7 @@ class SignatureWriter extends Signature
     /**
      * @param string $digestAlgorithm
      */
-    public function __construct(X509Certificate $certificate = null, XMLSecurityKey $xmlSecurityKey = null, $digestAlgorithm = XMLSecurityDSig::SHA1)
+    public function __construct(?X509Certificate $certificate = null, ?XMLSecurityKey $xmlSecurityKey = null, $digestAlgorithm = XMLSecurityDSig::SHA1)
     {
         $this->certificate = $certificate;
         $this->xmlSecurityKey = $xmlSecurityKey;

--- a/src/Provider/NameID/FixedNameIdProvider.php
+++ b/src/Provider/NameID/FixedNameIdProvider.php
@@ -10,7 +10,7 @@ class FixedNameIdProvider implements NameIdProviderInterface
     /** @var NameID|null */
     protected $nameId;
 
-    public function __construct(NameID $nameId = null)
+    public function __construct(?NameID $nameId = null)
     {
         $this->nameId = $nameId;
     }
@@ -18,7 +18,7 @@ class FixedNameIdProvider implements NameIdProviderInterface
     /**
      * @return FixedNameIdProvider
      */
-    public function setNameId(NameID $nameId = null)
+    public function setNameId(?NameID $nameId = null)
     {
         $this->nameId = $nameId;
 

--- a/src/Store/Credential/Factory/CredentialFactory.php
+++ b/src/Store/Credential/Factory/CredentialFactory.php
@@ -36,7 +36,7 @@ class CredentialFactory
         EntityDescriptorStoreInterface $spEntityDescriptorStore,
         $ownEntityId,
         CredentialStoreInterface $ownCredentialStore,
-        array $extraCredentials = null
+        ?array $extraCredentials = null
     ) {
         return $this->build(
             $idpEntityDescriptorStore,
@@ -56,7 +56,7 @@ class CredentialFactory
         EntityDescriptorStoreInterface $idpEntityDescriptorStore,
         EntityDescriptorStoreInterface $spEntityDescriptorStore,
         array $ownCredentials,
-        array $extraCredentials = null
+        ?array $extraCredentials = null
     ) {
         if (empty($ownCredentials)) {
             throw new LightSamlBuildException('There are no own credentials');

--- a/src/Store/TrustOptions/FixedTrustOptionsStore.php
+++ b/src/Store/TrustOptions/FixedTrustOptionsStore.php
@@ -12,7 +12,7 @@ class FixedTrustOptionsStore implements TrustOptionsStoreInterface
     /**
      * @param TrustOptions $option
      */
-    public function __construct(TrustOptions $option = null)
+    public function __construct(?TrustOptions $option = null)
     {
         $this->option = $option;
     }
@@ -20,7 +20,7 @@ class FixedTrustOptionsStore implements TrustOptionsStoreInterface
     /**
      * @return FixedTrustOptionsStore
      */
-    public function setTrustOptions(TrustOptions $trustOptions = null)
+    public function setTrustOptions(?TrustOptions $trustOptions = null)
     {
         $this->option = $trustOptions;
 

--- a/tests/Action/Profile/Outbound/Message/AbstractResolveEndpointActionTest.php
+++ b/tests/Action/Profile/Outbound/Message/AbstractResolveEndpointActionTest.php
@@ -74,9 +74,9 @@ abstract class AbstractResolveEndpointActionTest extends BaseTestCase
      */
     protected function createContext(
         $ownRole = ProfileContext::ROLE_IDP,
-        SamlMessage $inboundMessage = null,
-        Endpoint $endpoint = null,
-        EntityDescriptor $partyEntityDescriptor = null,
+        ?SamlMessage $inboundMessage = null,
+        ?Endpoint $endpoint = null,
+        ?EntityDescriptor $partyEntityDescriptor = null,
         $profileId = Profiles::SSO_IDP_RECEIVE_AUTHN_REQUEST
     ) {
         $context = $this->getProfileContext($profileId, $ownRole);

--- a/tests/Context/Profile/Helper/MessageContextHelperTest.php
+++ b/tests/Context/Profile/Helper/MessageContextHelperTest.php
@@ -58,7 +58,7 @@ class MessageContextHelperTest extends BaseTestCase
     /**
      * @dataProvider helperProvider
      */
-    public function test__helper($method, SamlMessage $message = null, $expectedException = null, $expectedMessage = null)
+    public function test__helper($method, ?SamlMessage $message = null, $expectedException = null, $expectedMessage = null)
     {
         $context = new MessageContext();
         if ($message) {

--- a/tests/Context/Profile/MessageContextTest.php
+++ b/tests/Context/Profile/MessageContextTest.php
@@ -32,7 +32,7 @@ class MessageContextTest extends BaseTestCase
     /**
      * @dataProvider message_as_concrete_type_provider
      */
-    public function test_message_as_concrete_type($method, $hasValue, SamlMessage $message = null)
+    public function test_message_as_concrete_type($method, $hasValue, ?SamlMessage $message = null)
     {
         $context = new MessageContext();
         if ($message) {

--- a/tests/Fixtures/Meta/TimeProviderMock.php
+++ b/tests/Fixtures/Meta/TimeProviderMock.php
@@ -12,7 +12,7 @@ class TimeProviderMock implements TimeProviderInterface
     /**
      * @param \DateTime $value
      */
-    public function __construct(\DateTime $value = null)
+    public function __construct(?\DateTime $value = null)
     {
         $this->value = $value;
     }

--- a/tests/Functional/Bridge/Pimple/ProfileTest.php
+++ b/tests/Functional/Bridge/Pimple/ProfileTest.php
@@ -159,7 +159,7 @@ class ProfileTest extends BaseTestCase
         $this->assertInstanceOf(\LightSaml\Store\EntityDescriptor\EntityDescriptorStoreInterface::class, $buildContainer->getPartyContainer()->getSpEntityDescriptorStore());
     }
 
-    private function getBuildContainer($inResponseTo = null, TimeProviderInterface $timeProvider = null)
+    private function getBuildContainer($inResponseTo = null, ?TimeProviderInterface $timeProvider = null)
     {
         $pimple = new Container();
 

--- a/tests/Helper/ContactPersonChecker.php
+++ b/tests/Helper/ContactPersonChecker.php
@@ -15,7 +15,7 @@ class ContactPersonChecker
         $surName,
         $email,
         $phone,
-        ContactPerson $contact = null
+        ?ContactPerson $contact = null
     ) {
         $test->assertNotNull($contact);
         $test->assertEquals($type, $contact->getContactType());

--- a/tests/Helper/EndpointChecker.php
+++ b/tests/Helper/EndpointChecker.php
@@ -7,7 +7,7 @@ use LightSaml\Tests\BaseTestCase;
 
 class EndpointChecker
 {
-    public static function check(BaseTestCase $test, $binding, $location, Endpoint $svc = null)
+    public static function check(BaseTestCase $test, $binding, $location, ?Endpoint $svc = null)
     {
         $test->assertNotNull($svc);
         $test->assertEquals($binding, $svc->getBinding());

--- a/tests/Helper/IndexedEndpointChecker.php
+++ b/tests/Helper/IndexedEndpointChecker.php
@@ -7,7 +7,7 @@ use LightSaml\Tests\BaseTestCase;
 
 class IndexedEndpointChecker
 {
-    public static function check(BaseTestCase $test, $binding, $location, $index, $isDefault, IndexedEndpoint $svc = null)
+    public static function check(BaseTestCase $test, $binding, $location, $index, $isDefault, ?IndexedEndpoint $svc = null)
     {
         EndpointChecker::check($test, $binding, $location, $svc);
         $test->assertEquals($index, $svc->getIndex());

--- a/tests/Helper/KeyDescriptorChecker.php
+++ b/tests/Helper/KeyDescriptorChecker.php
@@ -7,7 +7,7 @@ use LightSaml\Tests\BaseTestCase;
 
 class KeyDescriptorChecker
 {
-    public static function checkCertificateCN(BaseTestCase $test, $use, $cn, KeyDescriptor $kd = null)
+    public static function checkCertificateCN(BaseTestCase $test, $use, $cn, ?KeyDescriptor $kd = null)
     {
         $test->assertNotNull($kd);
         $test->assertEquals($use, $kd->getUse());

--- a/tests/Helper/OrganizationChecker.php
+++ b/tests/Helper/OrganizationChecker.php
@@ -7,7 +7,7 @@ use LightSaml\Tests\BaseTestCase;
 
 class OrganizationChecker
 {
-    public static function check(BaseTestCase $test, $name, $display, $url, Organization $organization = null)
+    public static function check(BaseTestCase $test, $name, $display, $url, ?Organization $organization = null)
     {
         $test->assertNotNull($organization);
         $test->assertEquals($name, $organization->getOrganizationName());


### PR DESCRIPTION
Implicitly nullable parameter declarations are [deprecated from PHP 8.4 on](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated) and will be removed in PHP 9.