### PR TITLE
fix: RoleDescriptor.php::getAllKeyDescriptorsByUse() dont fail on null keyDescriptors

### DIFF
--- a/src/Model/Metadata/RoleDescriptor.php
+++ b/src/Model/Metadata/RoleDescriptor.php
@@ -155,9 +155,12 @@ abstract class RoleDescriptor extends AbstractSamlModel
     public function getAllKeyDescriptorsByUse($use)
     {
         $result = [];
-        foreach ($this->getAllKeyDescriptors() as $kd) {
-            if ($kd->getUse() == $use) {
-                $result[] = $kd;
+
+        if ($this->getAllKeyDescriptors()) {
+            foreach ($this->getAllKeyDescriptors() as $kd) {
+                if ($kd->getUse() == $use) {
+                    $result[] = $kd;
+                }
             }
         }
 

--- a/tests/Model/Metadata/RoleDescriptorTest.php
+++ b/tests/Model/Metadata/RoleDescriptorTest.php
@@ -4,6 +4,7 @@ namespace Tests\Model\Metadata;
 
 use DateTime;
 use InvalidArgumentException;
+use LightSaml\Model\Metadata\KeyDescriptor;
 use LightSaml\Model\XmlDSig\SignatureWriter;
 use Tests\BaseTestCase;
 use Tests\Fixtures\Model\Metadata\RoleDescriptorMock;
@@ -42,6 +43,18 @@ class RoleDescriptorTest extends BaseTestCase
     {
         $rd = new RoleDescriptorMock();
         $this->assertNull($rd->getFirstKeyDescriptor());
+    }
+
+    public function test__get_all_key_descriptors_returns_null_when_empty()
+    {
+        $rd = new RoleDescriptorMock();
+        $this->assertNull($rd->getAllKeyDescriptors());
+    }
+
+    public function test__get_all_key_descriptors_by_use_returns_empty_array()
+    {
+        $rd = new RoleDescriptorMock();
+        $this->assertIsArray($rd->getAllKeyDescriptorsByUse(KeyDescriptor::USE_SIGNING));
     }
 
     public function test__add_signature()


### PR DESCRIPTION
We encountered this exception when receiving a (possibly) invalid payload from a SAML callback:

```
ErrorException: foreach() argument must be of type array|object, null given
#73 /vendor/litesaml/lightsaml/src/Model/Metadata/RoleDescriptor.php(158): Illuminate\Foundation\Bootstrap\HandleExceptions::handleError
#72 /vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(256): Illuminate\Foundation\Bootstrap\HandleExceptions::Illuminate\Foundation\Bootstrap\{closure}
#71 /vendor/litesaml/lightsaml/src/Model/Metadata/RoleDescriptor.php(158): LightSaml\Model\Metadata\RoleDescriptor::getAllKeyDescriptorsByUse
#70 /vendor/socialiteproviders/saml2/Provider.php(539): SocialiteProviders\Saml2\Provider::validateSignature
#69 /vendor/socialiteproviders/saml2/Provider.php(588): SocialiteProviders\Saml2\Provider::user
#68 /app/Services/Integration/Drivers/Saml/SamlDriver.php(38): App\Services\Integration\Drivers\Saml\SamlDriver::App\Services\Integration\Drivers\Saml\{closure}
...
```

This is due to iterating on a `RoleDescription::$keyDescriptors`, which is `null` until a single key descriptor is added.

This exception can be prevented by checking if the value is truthy (a non-empty array) before attempting to iterate.

This same approach is performed on other methods, so I implemented the same here:

https://github.com/litesaml/lightsaml/blob/8c73f6f519b0d5e3ccf7f051cfcdc029f33e1d3f/src/Model/Metadata/RoleDescriptor.php#L175-L186

Thanks for work on this package! ❤️ 