### PR TITLE
Remove abstract declaration from Signature class

### DIFF
--- a/src/Model/XmlDSig/Signature.php
+++ b/src/Model/XmlDSig/Signature.php
@@ -2,9 +2,12 @@
 
 namespace LightSaml\Model\XmlDSig;
 
+use DOMNode;
 use LightSaml\Model\AbstractSamlModel;
+use LightSaml\Model\Context\DeserializationContext;
+use LightSaml\Model\Context\SerializationContext;
 
-abstract class Signature extends AbstractSamlModel
+class Signature extends AbstractSamlModel
 {
     /**
      * @return string
@@ -12,5 +15,21 @@ abstract class Signature extends AbstractSamlModel
     protected function getIDName()
     {
         return 'ID';
+    }
+
+    /**
+     * @return void
+     */
+    public function serialize(DOMNode $parent, SerializationContext $context)
+    {
+        //
+    }
+
+    /**
+     * @return void
+     */
+    public function deserialize(DOMNode $node, DeserializationContext $context)
+    {
+        //
     }
 }


### PR DESCRIPTION
This PR removes the `abstract` declaration from the Signature class so that it can be instantiated. However, SAML/XML is out of my wheelhouse, so I have no idea what `serialize` and `deserialize` are supposed to do here - simply allowing it to be instantiated works for my use-case.

Closes #92 