### PR TITLE
fix: bump dependencies to address security vulnerabilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,15 +28,15 @@
     },
     "require": {
         "php": "^8.1",
-        "robrichards/xmlseclibs": "^3.1.4",
-        "symfony/http-foundation": "^6.0|^7.0|^8.0",
+        "robrichards/xmlseclibs": "^3.1.5",
+        "symfony/http-foundation": "^6.4.41|^7.4.13|^8.0.13",
         "psr/event-dispatcher": "^1.0",
         "litesaml/schemas": "^3.0",
         "psr/log": "^3.0"
     },
     "require-dev": {
         "pimple/pimple": "~3.0",
-        "phpunit/phpunit": "^10.1",
+        "phpunit/phpunit": "^10.5.62",
         "mockery/mockery": "^1.4.4",
         "rector/rector": "^1.2.2",
         "phpstan/phpstan": "^1.8",


### PR DESCRIPTION
## Summary

- `robrichards/xmlseclibs` `^3.1.4` → `^3.1.5` (CVE-2026-32313, CVE-2025-66578)
- `symfony/http-foundation` `^6.0|^7.0|^8.0` → `^6.4.41|^7.4.13|^8.0.13` (CVE-2025-64500, CVE-2026-48736)
- `phpunit/phpunit` `^10.1` → `^10.5.62` (CVE-2026-24765)

> **Note:** Les branches Symfony 6.0–6.3 et 7.0–7.3 n'ont pas de patch disponible en amont et ne sont plus couvertes par cette contrainte.