### PR TITLE
feat: include AssertionConsumerServiceURL in outbound AuthnRequest

### DIFF
--- a/src/Action/Profile/Outbound/AuthnRequest/ACSUrlAction.php
+++ b/src/Action/Profile/Outbound/AuthnRequest/ACSUrlAction.php
@@ -7,7 +7,6 @@ use LightSaml\Context\Profile\Helper\LogHelper;
 use LightSaml\Context\Profile\Helper\MessageContextHelper;
 use LightSaml\Context\Profile\ProfileContext;
 use LightSaml\Criteria\CriteriaSet;
-use LightSaml\Error\LightSamlContextException;
 use LightSaml\Model\Metadata\AssertionConsumerService;
 use LightSaml\Model\Metadata\SpSsoDescriptor;
 use LightSaml\Resolver\Endpoint\Criteria\BindingCriteria;
@@ -17,7 +16,6 @@ use LightSaml\Resolver\Endpoint\EndpointResolverInterface;
 use LightSaml\SamlConstants;
 use Psr\Log\LoggerInterface;
 
-// TODO ACSUrlAction not used in profile builder, has to be added
 class ACSUrlAction extends AbstractProfileAction
 {
     public function __construct(LoggerInterface $logger, private readonly EndpointResolverInterface $endpointResolver)
@@ -37,9 +35,12 @@ class ACSUrlAction extends AbstractProfileAction
 
         $endpoints = $this->endpointResolver->resolve($criteriaSet, $ownEntityDescriptor->getAllEndpoints());
         if (empty($endpoints)) {
-            $message = 'Missing ACS Service with HTTP POST binding in own SP SSO Descriptor';
-            $this->logger->error($message, LogHelper::getActionErrorContext($context, $this));
-            throw new LightSamlContextException($context, $message);
+            $this->logger->debug(
+                'No ACS Service with HTTP POST binding found in own SP SSO Descriptor, skipping ACS URL',
+                LogHelper::getActionErrorContext($context, $this)
+            );
+
+            return;
         }
 
         MessageContextHelper::asAuthnRequest($context->getOutboundContext())

--- a/src/Builder/Action/Profile/SingleSignOn/Sp/SsoSpSendAuthnRequestActionBuilder.php
+++ b/src/Builder/Action/Profile/SingleSignOn/Sp/SsoSpSendAuthnRequestActionBuilder.php
@@ -3,6 +3,7 @@
 namespace LightSaml\Builder\Action\Profile\SingleSignOn\Sp;
 
 use LightSaml\Action\DispatchEventAction;
+use LightSaml\Action\Profile\Outbound\AuthnRequest\ACSUrlAction;
 use LightSaml\Action\Profile\Outbound\AuthnRequest\CreateAuthnRequestAction;
 use LightSaml\Action\Profile\Outbound\Message\CreateMessageIssuerAction;
 use LightSaml\Action\Profile\Outbound\Message\DestinationAction;
@@ -31,6 +32,10 @@ class SsoSpSendAuthnRequestActionBuilder extends AbstractProfileActionBuilder
         ), 100);
         $this->add(new CreateAuthnRequestAction(
             $this->buildContainer->getSystemContainer()->getLogger()
+        ));
+        $this->add(new ACSUrlAction(
+            $this->buildContainer->getSystemContainer()->getLogger(),
+            $this->buildContainer->getServiceContainer()->getEndpointResolver()
         ));
         $this->add(new SetRelayStateAction(
             $this->buildContainer->getSystemContainer()->getLogger()

--- a/tests/Action/Profile/Outbound/AuthnRequest/ACSUrlActionTest.php
+++ b/tests/Action/Profile/Outbound/AuthnRequest/ACSUrlActionTest.php
@@ -5,7 +5,6 @@ namespace Tests\Action\Profile\Outbound\AuthnRequest;
 use LightSaml\Action\Profile\Outbound\AuthnRequest\ACSUrlAction;
 use LightSaml\Context\Profile\ProfileContext;
 use LightSaml\Criteria\CriteriaSet;
-use LightSaml\Error\LightSamlContextException;
 use LightSaml\Model\Metadata\AssertionConsumerService;
 use LightSaml\Model\Metadata\EntityDescriptor;
 use LightSaml\Model\Metadata\SpSsoDescriptor;
@@ -63,10 +62,8 @@ class ACSUrlActionTest extends BaseTestCase
         $this->assertEquals($endpoint->getLocation(), $authnRequest->getAssertionConsumerServiceURL());
     }
 
-    public function test_throws_context_exception_if_no_own_acs_service()
+    public function test_skips_silently_if_no_own_acs_service()
     {
-        $this->expectExceptionMessage("Missing ACS Service with HTTP POST binding in own SP SSO Descriptor");
-        $this->expectException(LightSamlContextException::class);
         $action = new ACSUrlAction(
             $loggerMock = $this->getLoggerMock(),
             $endpointResolverMock = $this->getEndpointResolverMock()
@@ -74,6 +71,7 @@ class ACSUrlActionTest extends BaseTestCase
 
         $context = new ProfileContext(Profiles::SSO_SP_SEND_AUTHN_REQUEST, ProfileContext::ROLE_SP);
         $context->getOwnEntityContext()->setEntityDescriptor($entityDescriptorMock = $this->getEntityDescriptorMock());
+        $context->getOutboundContext()->setMessage($authnRequest = new AuthnRequest());
 
         $entityDescriptorMock->expects($this->once())
             ->method('getAllEndpoints')
@@ -84,9 +82,11 @@ class ACSUrlActionTest extends BaseTestCase
             ->willReturn([]);
 
         $loggerMock->expects($this->once())
-            ->method('error');
+            ->method('debug');
 
         $action->execute($context);
+
+        $this->assertNull($authnRequest->getAssertionConsumerServiceURL());
     }
 
     /**


### PR DESCRIPTION
## Summary

- Adds `ACSUrlAction` to `SsoSpSendAuthnRequestActionBuilder` so the `AssertionConsumerServiceURL` attribute is automatically included in outbound `AuthnRequest` when an HTTP-POST ACS endpoint is declared in the SP metadata
- When no matching endpoint is found, the action skips silently (debug log) instead of throwing an exception, preserving backward compatibility with existing setups
- Updates `ACSUrlActionTest` to reflect the new non-throwing behavior

Closes #70