### PR TITLE
feat: return SamlMessage from binding receive() method

### DIFF
--- a/src/Binding/AbstractBinding.php
+++ b/src/Binding/AbstractBinding.php
@@ -5,6 +5,7 @@ namespace LightSaml\Binding;
 use LightSaml\Context\Profile\MessageContext;
 use LightSaml\Event\MessageReceived;
 use LightSaml\Event\MessageSent;
+use LightSaml\Model\Protocol\SamlMessage;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -59,5 +60,5 @@ abstract class AbstractBinding
      */
     abstract public function send(MessageContext $context, $destination = null);
 
-    abstract public function receive(Request $request, MessageContext $context);
+    abstract public function receive(Request $request, MessageContext $context): SamlMessage;
 }

--- a/src/Binding/HttpPostBinding.php
+++ b/src/Binding/HttpPostBinding.php
@@ -42,7 +42,7 @@ class HttpPostBinding extends AbstractBinding
         return $result;
     }
 
-    public function receive(Request $request, MessageContext $context)
+    public function receive(Request $request, MessageContext $context): SamlMessage
     {
         $post = $request->request->all();
         if (array_key_exists('SAMLRequest', $post)) {
@@ -70,5 +70,7 @@ class HttpPostBinding extends AbstractBinding
         }
 
         $context->setMessage($result);
+
+        return $result;
     }
 }

--- a/src/Binding/HttpRedirectBinding.php
+++ b/src/Binding/HttpRedirectBinding.php
@@ -32,11 +32,13 @@ class HttpRedirectBinding extends AbstractBinding
         return new RedirectResponse($url);
     }
 
-    public function receive(Request $request, MessageContext $context)
+    public function receive(Request $request, MessageContext $context): SamlMessage
     {
         $data = $this->parseQuery($request);
 
         $this->processData($data, $context);
+
+        return $context->getMessage();
     }
 
     /**


### PR DESCRIPTION
## Summary

- `AbstractBinding::receive()` now returns `SamlMessage` instead of `void`
- Both `HttpPostBinding` and `HttpRedirectBinding` return the deserialized message

## Context

The official documentation example showed:

```php
$response = $binding->receive($request, $messageContext);
print $response->getID(); // Fatal error: $response is null
```

Since `receive()` returned `void`, `$response` was always `null`. Users had to know to call `$messageContext->getMessage()` instead — which is not documented.

With this change, both patterns work:

```php
// New: assign directly from receive()
$message = $binding->receive($request, $messageContext);

// Existing: still works unchanged
$binding->receive($request, $messageContext);
$message = $messageContext->getMessage();
```

This is non-breaking: existing code that ignores the return value continues to work.

Closes #89