### PR TITLE
fix: use SignatureXmlReader instead of abstract Signature in RoleDescriptor

### DIFF
--- a/src/Model/Metadata/RoleDescriptor.php
+++ b/src/Model/Metadata/RoleDescriptor.php
@@ -10,6 +10,7 @@ use LightSaml\Model\AbstractSamlModel;
 use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Context\SerializationContext;
 use LightSaml\Model\XmlDSig\Signature;
+use LightSaml\Model\XmlDSig\SignatureXmlReader;
 use LightSaml\SamlConstants;
 
 abstract class RoleDescriptor extends AbstractSamlModel
@@ -319,7 +320,7 @@ abstract class RoleDescriptor extends AbstractSamlModel
             $context,
             'Signature',
             'ds',
-            Signature::class,
+            SignatureXmlReader::class,
             'addSignature'
         );
         $this->manyElementsFromXml(


### PR DESCRIPTION
Fixes #92

`RoleDescriptor::deserialize()` was passing `Signature::class` to `manyElementsFromXml()`, which calls `new $class()` internally. Since `Signature` is abstract, this caused a fatal error when deserializing metadata containing a `<ds:Signature>` element.

Replaced with `SignatureXmlReader::class`, the concrete implementation that handles XML signature deserialization.