### PR TITLE
refactor!: remove deprecated Serializable interface from state classes

### DIFF
--- a/src/Meta/ParameterBag.php
+++ b/src/Meta/ParameterBag.php
@@ -5,9 +5,8 @@ namespace LightSaml\Meta;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
-use Serializable;
 
-class ParameterBag implements IteratorAggregate, Countable, Serializable
+class ParameterBag implements IteratorAggregate, Countable
 {
     public function __construct(protected array $parameters = [])
     {
@@ -63,28 +62,12 @@ class ParameterBag implements IteratorAggregate, Countable, Serializable
         return count($this->parameters);
     }
 
-    /**
-     * @deprecated Since php 8.1. Use __serialize() instead
-     */
-    public function serialize(): string
-    {
-        return serialize($this->__serialize());
-    }
-
     public function __serialize(): array
     {
         return $this->parameters;
     }
 
-    /**
-     * @deprecated Since php 8.1. Use __unserialize() instead
-     */
-    public function unserialize($serialized): void
-    {
-        $this->__unserialize(unserialize($serialized));
-    }
-
-    public function __unserialize(array $serialized)
+    public function __unserialize(array $serialized): void
     {
         $this->parameters = $serialized;
     }

--- a/src/State/Request/RequestState.php
+++ b/src/State/Request/RequestState.php
@@ -3,9 +3,8 @@
 namespace LightSaml\State\Request;
 
 use LightSaml\Meta\ParameterBag;
-use Serializable;
 
-class RequestState implements Serializable
+class RequestState
 {
     private ParameterBag $parameters;
 
@@ -52,34 +51,11 @@ class RequestState implements Serializable
         return $this->parameters->get('nonce');
     }
 
-    /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
-     * String representation of object.
-     *
-     * @see http://php.net/manual/en/serializable.serialize.php
-     *
-     */
-    public function serialize(): string
-    {
-        return serialize($this->__serialize());
-    }
-
-    /**
-     * (PHP >= 8.1)
-     */
     public function __serialize(): array
     {
         $nonce = $this->parameters->get('nonce');
 
         return [$this->id, $nonce, $this->parameters->__serialize()];
-    }
-
-    /**
-     * @param string $serialized The string representation of the object
-     */
-    public function unserialize(string $serialized): void
-    {
-        $this->__unserialize(unserialize($serialized));
     }
 
     public function __unserialize(array $serialized): void

--- a/src/State/Sso/SsoSessionState.php
+++ b/src/State/Sso/SsoSessionState.php
@@ -5,9 +5,8 @@ namespace LightSaml\State\Sso;
 use DateTime;
 use LightSaml\Error\LightSamlException;
 use LightSaml\Meta\ParameterBag;
-use Serializable;
 
-class SsoSessionState implements Serializable
+class SsoSessionState
 {
     protected ?string $idpEntityId = null;
 
@@ -186,15 +185,6 @@ class SsoSessionState implements Serializable
         throw new LightSamlException(sprintf('Party "%s" is not included in sso session between "%s" and "%s"', $partyId, $this->idpEntityId, $this->spEntityId));
     }
 
-    public function serialize(): string
-    {
-        return serialize($this->__serialize());
-    }
-
-    /**
-     * (PHP >= 8.1)
-     * String representation of object.
-     */
     public function __serialize(): array
     {
         return [
@@ -211,14 +201,6 @@ class SsoSessionState implements Serializable
         ];
     }
 
-    public function unserialize(string $serialized): void
-    {
-        $this->__unserialize(unserialize($serialized));
-    }
-
-    /**
-     * (PHP >= 8.1)
-     */
     public function __unserialize(array $data): void
     {
         // add a few extra elements in the array to ensure that we have enough keys when unserializing

--- a/src/State/Sso/SsoState.php
+++ b/src/State/Sso/SsoState.php
@@ -3,9 +3,8 @@
 namespace LightSaml\State\Sso;
 
 use LightSaml\Meta\ParameterBag;
-use Serializable;
 
-class SsoState implements Serializable
+class SsoState
 {
     private ?string $localSessionId = null;
 
@@ -130,14 +129,6 @@ class SsoState implements Serializable
         return $this;
     }
 
-    public function serialize(): string
-    {
-        return serialize($this->__serialize());
-    }
-
-    /**
-     * (PHP >= 8.1)
-     */
     public function __serialize(): array
     {
         return [
@@ -146,11 +137,6 @@ class SsoState implements Serializable
             [],
             $this->parameters,
         ];
-    }
-
-    public function unserialize(string $serialized): void
-    {
-        $this->__unserialize(unserialize($serialized));
     }
 
     public function __unserialize(array $data): void

--- a/tests/State/Sso/SsoSessionStateTest.php
+++ b/tests/State/Sso/SsoSessionStateTest.php
@@ -54,10 +54,9 @@ class SsoSessionStateTest extends BaseTestCase
             ->setLastAuthOn($lastAuthOn = new DateTime('2015-10-27 10:00:00'))
             ->setSessionInstant($sessionInstant = new DateTime('2015-10-27 06:00:00'))
         ;
-        $data = $state->serialize();
+        $data = serialize($state);
 
-        $otherState = new SsoSessionState();
-        $otherState->unserialize($data);
+        $otherState = unserialize($data);
 
         $this->assertEquals($state->getIdpEntityId(), $otherState->getIdpEntityId());
         $this->assertEquals($state->getSpEntityId(), $otherState->getSpEntityId());

--- a/tests/State/Sso/SsoStateTest.php
+++ b/tests/State/Sso/SsoStateTest.php
@@ -156,10 +156,9 @@ class SsoStateTest extends BaseTestCase
         $state->addOption('b', 2);
         $sessions = $state->getSsoSessions();
 
-        $data = $state->serialize();
+        $data = serialize($state);
 
-        $otherState = new SsoState();
-        $otherState->unserialize($data);
+        $otherState = unserialize($data);
         $otherSessions = $otherState->getSsoSessions();
 
         $this->assertEquals($state->getOptions(), $otherState->getOptions());


### PR DESCRIPTION
Drop the Serializable interface (deprecated since PHP 8.1) from ParameterBag, SsoState, SsoSessionState, and RequestState. The __serialize()/__unserialize() magic methods are sufficient and are the modern PHP approach.