### PR TITLE
fix: reject XML Signature Wrapping (XSW) attacks in SignatureXmlReader

### DIFF
--- a/src/Model/XmlDSig/SignatureXmlReader.php
+++ b/src/Model/XmlDSig/SignatureXmlReader.php
@@ -55,6 +55,9 @@ class SignatureXmlReader extends AbstractSignatureReader
             return false;
         }
 
+        // Must run before validateReference() because that call detaches sigNode from the document.
+        $this->assertNoXmlSignatureWrapping();
+
         try {
             $this->signature->validateReference();
         } catch (Exception $e) {
@@ -68,6 +71,81 @@ class SignatureXmlReader extends AbstractSignatureReader
         }
 
         return true;
+    }
+
+    /**
+     * Rejects XML Signature Wrapping (XSW) attacks by verifying that each fragment Reference URI
+     * points to the element that directly contains this ds:Signature, and that this ID is unique
+     * in the document. Duplicate IDs are illegal in XML and are the prerequisite for XSW attacks
+     * where an attacker buries a genuine signed element elsewhere in the document and presents a
+     * forged element with a copied signature as a direct-child assertion.
+     *
+     * @throws LightSamlSecurityException
+     */
+    private function assertNoXmlSignatureWrapping(): void
+    {
+        $sigNode = $this->signature->sigNode;
+        if (!$sigNode instanceof DOMElement) {
+            return;
+        }
+
+        $doc = $sigNode->ownerDocument;
+        $xpath = new DOMXPath($doc);
+        $xpath->registerNamespace('ds', XMLSecurityDSig::XMLDSIGNS);
+
+        $refs = $xpath->query('./ds:SignedInfo/ds:Reference', $sigNode);
+        if (!$refs || $refs->length === 0) {
+            return;
+        }
+
+        foreach ($refs as $ref) {
+            /** @var DOMElement $ref */
+            $uri = $ref->getAttribute('URI');
+            if (!str_starts_with($uri, '#') || $uri === '#') {
+                continue;
+            }
+            $id = substr($uri, 1);
+
+            $parent = $sigNode->parentNode;
+            if (!$parent instanceof DOMElement) {
+                throw new LightSamlSecurityException('Enveloped signature has no parent element');
+            }
+
+            // Verify the parent element carries the referenced ID, using the same attribute names
+            // that xmlseclibs uses (hardcoded 'Id' plus whatever idKeys are registered).
+            $idAttrNames = array_merge(['Id'], $this->signature->idKeys);
+            $parentId = null;
+            foreach ($idAttrNames as $attrName) {
+                $val = $parent->getAttribute($attrName);
+                if ($val !== '') {
+                    $parentId = $val;
+                    break;
+                }
+            }
+
+            if ($parentId !== $id) {
+                throw new LightSamlSecurityException(sprintf(
+                    'Signature Reference URI "#%s" does not match the enclosing element\'s ID "%s"',
+                    $id,
+                    (string) $parentId
+                ));
+            }
+
+            // Build the same XPath predicate that xmlseclibs uses to resolve the reference, then
+            // count matches. More than one element with the same ID means the document is malformed
+            // and a wrapping attack is almost certainly in progress.
+            $iDlist = '@Id="' . $id . '"';
+            foreach ($this->signature->idKeys as $idKey) {
+                $iDlist .= ' or @' . $idKey . '="' . $id . '"';
+            }
+            $matches = $xpath->query('//*[' . $iDlist . ']');
+            if ($matches !== false && $matches->length > 1) {
+                throw new LightSamlSecurityException(sprintf(
+                    'Duplicate ID "%s" found in document: XML Signature Wrapping attack detected',
+                    $id
+                ));
+            }
+        }
     }
 
     /**

--- a/tests/Functional/Model/Protocol/XmlSignatureWrappingTest.php
+++ b/tests/Functional/Model/Protocol/XmlSignatureWrappingTest.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Tests\Functional\Model\Protocol;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use LightSaml\Context\Model\DeserializationContext;
+use LightSaml\Context\Model\SerializationContext;
+use LightSaml\Credential\KeyHelper;
+use LightSaml\Credential\X509Certificate;
+use LightSaml\Error\LightSamlSecurityException;
+use LightSaml\Helper;
+use LightSaml\Model\Assertion\Assertion;
+use LightSaml\Model\Assertion\Issuer;
+use LightSaml\Model\Assertion\NameID;
+use LightSaml\Model\Assertion\Subject;
+use LightSaml\Model\Protocol\Response;
+use LightSaml\Model\Protocol\Status;
+use LightSaml\Model\Protocol\StatusCode;
+use LightSaml\Model\XmlDSig\SignatureWriter;
+use LightSaml\Model\XmlDSig\SignatureXmlReader;
+use LightSaml\SamlConstants;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+use Tests\BaseTestCase;
+
+/**
+ * Regression tests for XML Signature Wrapping (XSW) attacks.
+ *
+ * An attacker who captures a genuine signed assertion can bury it (without its ds:Signature)
+ * inside samlp:Extensions, making it the first @ID element in document order. xmlseclibs then
+ * resolves the Reference URI to this element and validates the digest against it — successfully.
+ * A forged direct-child assertion carrying the same ID, a verbatim copy of the genuine signature,
+ * and attacker-controlled claims is what LightSAML actually collects and reads.
+ *
+ * The fix rejects this by verifying (a) the ds:Signature's parent element carries the referenced ID
+ * and (b) that ID is unique in the document. Both checks run before validateReference() detaches
+ * the signature node.
+ */
+class XmlSignatureWrappingTest extends BaseTestCase
+{
+    public function test_valid_signed_assertion_is_still_accepted(): void
+    {
+        $assertionId = Helper::generateID();
+        $response = $this->buildSignedResponse($assertionId, 'alice@example.com');
+
+        $serCtx = new SerializationContext();
+        $response->serialize($serCtx->getDocument(), $serCtx);
+        $xml = $serCtx->getDocument()->saveXML();
+
+        $desCtx = new DeserializationContext();
+        $desCtx->getDocument()->loadXML($xml);
+        $deserialized = new Response();
+        $deserialized->deserialize($desCtx->getDocument(), $desCtx);
+
+        /** @var SignatureXmlReader $sig */
+        $sig = $deserialized->getAllAssertions()[0]->getSignature();
+        $this->assertTrue($sig->validate(KeyHelper::createPublicKey($this->getCertificate())));
+    }
+
+    public function test_rejects_xsw_duplicate_id_in_document(): void
+    {
+        $assertionId = Helper::generateID();
+        $response = $this->buildSignedResponse($assertionId, 'alice@example.com');
+
+        $serCtx = new SerializationContext();
+        $response->serialize($serCtx->getDocument(), $serCtx);
+        $genuineXml = $serCtx->getDocument()->saveXML();
+
+        $tamperedXml = $this->buildXswPayload($genuineXml, $assertionId);
+
+        $desCtx = new DeserializationContext();
+        $desCtx->getDocument()->loadXML($tamperedXml);
+        $tamperedResponse = new Response();
+        $tamperedResponse->deserialize($desCtx->getDocument(), $desCtx);
+
+        $assertions = $tamperedResponse->getAllAssertions();
+        $this->assertCount(1, $assertions, 'LightSAML should collect only the forged direct-child assertion');
+
+        // Confirm the collected assertion carries the attacker claims (pre-condition for the bypass)
+        $nameId = $assertions[0]->getSubject()->getNameID()->getValue();
+        $this->assertSame('attacker@evil.com', $nameId, 'Collected assertion must carry attacker NameID');
+
+        // Signature validation must reject the tampered document
+        $this->expectException(LightSamlSecurityException::class);
+
+        /** @var SignatureXmlReader $sig */
+        $sig = $assertions[0]->getSignature();
+        $sig->validate(KeyHelper::createPublicKey($this->getCertificate()));
+    }
+
+    public function test_rejects_xsw_reference_uri_mismatch(): void
+    {
+        // Build a response, then move the signature into a different element (no ID match).
+        $assertionId = Helper::generateID();
+        $response = $this->buildSignedResponse($assertionId, 'alice@example.com');
+
+        $serCtx = new SerializationContext();
+        $response->serialize($serCtx->getDocument(), $serCtx);
+        $xml = $serCtx->getDocument()->saveXML();
+
+        $doc = new DOMDocument();
+        $doc->loadXML($xml);
+        $xp = new DOMXPath($doc);
+        $xp->registerNamespace('saml', SamlConstants::NS_ASSERTION);
+        $xp->registerNamespace('ds', 'http://www.w3.org/2000/09/xmldsig#');
+
+        // Move the ds:Signature to a wrapper element that has a *different* ID
+        $assertion = $xp->query('//saml:Assertion[@ID="' . $assertionId . '"]')->item(0);
+        $sig = $xp->query('./ds:Signature', $assertion)->item(0);
+
+        $wrapper = $doc->createElementNS(SamlConstants::NS_ASSERTION, 'saml:Assertion');
+        $wrapper->setAttribute('ID', '_different_id');
+        $wrapper->setAttribute('Version', '2.0');
+        $wrapper->setAttribute('IssueInstant', '2024-01-01T00:00:00Z');
+        $wrapper->appendChild($sig);
+        $assertion->parentNode->appendChild($wrapper);
+
+        $desCtx = new DeserializationContext();
+        $desCtx->getDocument()->loadXML($doc->saveXML());
+        $deserialized = new Response();
+        $deserialized->deserialize($desCtx->getDocument(), $desCtx);
+
+        // Find the assertion that still has a signature (the wrapper)
+        $sigAssertion = null;
+        foreach ($deserialized->getAllAssertions() as $a) {
+            if ($a->getSignature() instanceof SignatureXmlReader) {
+                $sigAssertion = $a;
+            }
+        }
+        $this->assertNotNull($sigAssertion);
+
+        $this->expectException(LightSamlSecurityException::class);
+
+        /** @var SignatureXmlReader $reader */
+        $reader = $sigAssertion->getSignature();
+        $reader->validate(KeyHelper::createPublicKey($this->getCertificate()));
+    }
+
+    private function buildSignedResponse(string $assertionId, string $nameIdValue): Response
+    {
+        return (new Response())
+            ->setID(Helper::generateID())
+            ->setIssuer(new Issuer('https://idp.example.com'))
+            ->setStatus(new Status(new StatusCode(SamlConstants::STATUS_SUCCESS)))
+            ->addAssertion(
+                (new Assertion())
+                    ->setId($assertionId)
+                    ->setIssuer(new Issuer('https://idp.example.com'))
+                    ->setSubject(
+                        (new Subject())->setNameID(
+                            new NameID($nameIdValue, SamlConstants::NAME_ID_FORMAT_EMAIL)
+                        )
+                    )
+                    ->setSignature(new SignatureWriter($this->getCertificate(), $this->getPrivateKey()))
+            );
+    }
+
+    /**
+     * Transforms a genuine signed response into an XSW payload:
+     * - Strips ds:Signature from the genuine assertion and buries it in samlp:Extensions
+     *   (making it the first @ID element in document order, which xmlseclibs resolves to)
+     * - Injects a forged direct-child assertion with the same ID, the copied ds:Signature,
+     *   and attacker-controlled NameID
+     */
+    private function buildXswPayload(string $genuineXml, string $assertionId): string
+    {
+        $doc = new DOMDocument();
+        $doc->loadXML($genuineXml);
+
+        $xp = new DOMXPath($doc);
+        $xp->registerNamespace('samlp', SamlConstants::NS_PROTOCOL);
+        $xp->registerNamespace('saml', SamlConstants::NS_ASSERTION);
+        $xp->registerNamespace('ds', 'http://www.w3.org/2000/09/xmldsig#');
+
+        /** @var DOMElement $resp */
+        $resp = $doc->documentElement;
+
+        /** @var DOMElement $genuineAssertion */
+        $genuineAssertion = $xp->query('//saml:Assertion[@ID="' . $assertionId . '"]')->item(0);
+
+        // Copy the signature verbatim (to be pasted into the forged assertion)
+        $copiedSig = $xp->query('./ds:Signature', $genuineAssertion)->item(0)->cloneNode(true);
+
+        // Build the buried element: genuine assertion content without its ds:Signature
+        $buried = $genuineAssertion->cloneNode(true);
+        $buried->removeChild($xp->query('./ds:Signature', $buried)->item(0));
+
+        // samlp:Extensions wraps the buried genuine assertion — it will be first in document order
+        $ext = $doc->createElementNS(SamlConstants::NS_PROTOCOL, 'samlp:Extensions');
+        $ext->appendChild($buried);
+        $resp->replaceChild($ext, $genuineAssertion);
+
+        // Forged assertion: same ID, copied signature, attacker NameID
+        $forged = $doc->createElementNS(SamlConstants::NS_ASSERTION, 'saml:Assertion');
+        $forged->setAttribute('ID', $assertionId);
+        $forged->setAttribute('Version', '2.0');
+        $forged->setAttribute('IssueInstant', '2024-01-01T00:00:00Z');
+
+        $issuer = $doc->createElementNS(SamlConstants::NS_ASSERTION, 'saml:Issuer');
+        $issuer->textContent = 'https://idp.example.com';
+        $forged->appendChild($issuer);
+
+        $forged->appendChild($copiedSig);
+
+        $subject = $doc->createElementNS(SamlConstants::NS_ASSERTION, 'saml:Subject');
+        $nameId = $doc->createElementNS(SamlConstants::NS_ASSERTION, 'saml:NameID');
+        $nameId->setAttribute('Format', SamlConstants::NAME_ID_FORMAT_EMAIL);
+        $nameId->textContent = 'attacker@evil.com';
+        $subject->appendChild($nameId);
+        $forged->appendChild($subject);
+
+        $resp->appendChild($forged);
+
+        return $doc->saveXML();
+    }
+
+    private function getCertificate(): X509Certificate
+    {
+        return X509Certificate::fromFile(__DIR__ . '/../../../resources/web_saml.crt');
+    }
+
+    private function getPrivateKey(): XMLSecurityKey
+    {
+        return KeyHelper::createPrivateKey(__DIR__ . '/../../../resources/web_saml.key', null, true);
+    }
+}


### PR DESCRIPTION
## Security fix: XML Signature Wrapping (XSW)

Reported by [@ericchiang](https://github.com/ericchiang).

### Vulnerability

LightSAML 5.0.0 (and 4.6.1) is vulnerable to an XML Signature Wrapping attack that allows an attacker who has captured one genuine signed assertion to have LightSAML accept a fully attacker-authored assertion as IdP-signed, leading to **authentication bypass / privilege escalation**.

The root cause is a mismatch between two layers:

| Layer | Behaviour |
|---|---|
| `manyElementsFromXml` (LightSAML) | Collects assertions via a *relative* XPath (`saml:Assertion`) — only **direct children** of `<samlp:Response>` |
| `validateReference()` (xmlseclibs) | Resolves `URI="#id"` with a *document-wide* XPath (`//*[@Id="…" or @ID="…"]`) and takes `.item(0)` — the **first** matching element in document order |

An attacker exploits this gap by:

1. Taking a genuine signed assertion and stripping its `<ds:Signature>` element, then embedding it inside `<samlp:Extensions>` — making it the first `@ID` match in document order, so xmlseclibs validates against it (digest matches).
2. Appending a **forged** direct-child `<saml:Assertion>` with the same `ID`, a verbatim copy of the genuine `<ds:Signature>`, and attacker-controlled claims (`NameID`, `Attributes`).

LightSAML collects only the forged direct-child assertion and reads claims from it, while xmlseclibs validates the signature against the genuine buried element. The result: signature validation passes, but the consumed identity is entirely attacker-controlled.

### Fix

In `SignatureXmlReader::validate()`, a new `assertNoXmlSignatureWrapping()` guard runs **before** `validateReference()` (xmlseclibs detaches the signature node during that call, so the check must come first). It enforces two invariants:

1. **Parent-ID match** — the `<ds:Signature>`'s parent element must carry the ID referenced by `URI="#…"`. This ensures the signature is genuinely enveloped in the element it claims to sign.
2. **Unique ID** — no other element in the document may share that ID. Duplicate IDs are illegal in XML (`xs:ID` type) and are the structural prerequisite for all XSW attacks.

The attribute names checked mirror exactly what xmlseclibs uses internally (`Id` hardcoded + registered `idKeys`, which LightSAML sets to `ID`).

### Tests

Three regression tests are added in `XmlSignatureWrappingTest`:

- `test_valid_signed_assertion_is_still_accepted` — normal happy path is unaffected
- `test_rejects_xsw_duplicate_id_in_document` — full XSW bypass scenario is blocked
- `test_rejects_xsw_reference_uri_mismatch` — signature moved to a wrapper element with a different ID is rejected