### PR TITLE
feat: reject Responses with duplicate assertion IDs

### DIFF
--- a/src/Action/Profile/Inbound/Response/UniqueAssertionIdValidatorAction.php
+++ b/src/Action/Profile/Inbound/Response/UniqueAssertionIdValidatorAction.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace LightSaml\Action\Profile\Inbound\Response;
+
+use LightSaml\Action\Profile\AbstractProfileAction;
+use LightSaml\Context\Profile\Helper\LogHelper;
+use LightSaml\Context\Profile\Helper\MessageContextHelper;
+use LightSaml\Context\Profile\ProfileContext;
+use LightSaml\Error\LightSamlContextException;
+
+/**
+ * Rejects an inbound Response that contains more than one assertion sharing the
+ * same ID. An assertion ID is an xsd:ID and MUST be unique within a document, so
+ * a Response that reuses one is malformed. This is a stateless, per-document
+ * check.
+ */
+class UniqueAssertionIdValidatorAction extends AbstractProfileAction
+{
+    protected function doExecute(ProfileContext $context): void
+    {
+        $response = MessageContextHelper::asResponse($context->getInboundContext());
+
+        $seen = [];
+        foreach ($response->getAllAssertions() as $assertion) {
+            $id = $assertion->getId();
+            if ($id === null || $id === '') {
+                continue;
+            }
+            if (isset($seen[$id])) {
+                $message = sprintf('Response contains more than one assertion with ID "%s"', $id);
+                $this->logger->error($message, LogHelper::getActionErrorContext($context, $this));
+
+                throw new LightSamlContextException($context, $message);
+            }
+            $seen[$id] = true;
+        }
+    }
+}

--- a/src/Builder/Action/Profile/SingleSignOn/Sp/SsoSpReceiveResponseActionBuilder.php
+++ b/src/Builder/Action/Profile/SingleSignOn/Sp/SsoSpReceiveResponseActionBuilder.php
@@ -16,6 +16,7 @@ use LightSaml\Action\Profile\Inbound\Response\HasAssertionsValidatorAction;
 use LightSaml\Action\Profile\Inbound\Response\HasAuthnStatementValidatorAction;
 use LightSaml\Action\Profile\Inbound\Response\HasBearerAssertionsValidatorAction;
 use LightSaml\Action\Profile\Inbound\Response\SpSsoStateAction;
+use LightSaml\Action\Profile\Inbound\Response\UniqueAssertionIdValidatorAction;
 use LightSaml\Action\Profile\Inbound\StatusResponse\InResponseToValidatorAction;
 use LightSaml\Action\Profile\Inbound\StatusResponse\StatusAction;
 use LightSaml\Build\Container\BuildContainerInterface;
@@ -79,6 +80,9 @@ class SsoSpReceiveResponseActionBuilder extends AbstractProfileActionBuilder
         ));
 
         $this->add(new HasAssertionsValidatorAction(
+            $this->buildContainer->getSystemContainer()->getLogger()
+        ));
+        $this->add(new UniqueAssertionIdValidatorAction(
             $this->buildContainer->getSystemContainer()->getLogger()
         ));
         $this->add(new HasAuthnStatementValidatorAction(

--- a/tests/Action/Profile/Inbound/Response/UniqueAssertionIdValidatorActionTest.php
+++ b/tests/Action/Profile/Inbound/Response/UniqueAssertionIdValidatorActionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+// tests/Action/Profile/Inbound/Response/UniqueAssertionIdValidatorActionTest.php
+
+namespace Tests\Action\Profile\Inbound\Response;
+
+use LightSaml\Action\Profile\Inbound\Response\UniqueAssertionIdValidatorAction;
+use LightSaml\Context\Profile\ProfileContext;
+use LightSaml\Error\LightSamlContextException;
+use LightSaml\Model\Assertion\Assertion;
+use LightSaml\Model\Protocol\Response;
+use LightSaml\Profile\Profiles;
+use Tests\BaseTestCase;
+
+class UniqueAssertionIdValidatorActionTest extends BaseTestCase
+{
+    private function context(Response $response): ProfileContext
+    {
+        $context = new ProfileContext(Profiles::SSO_SP_RECEIVE_RESPONSE, ProfileContext::ROLE_SP);
+        $context->getInboundContext()->setMessage($response);
+
+        return $context;
+    }
+
+    public function test_constructs_with_logger(): void
+    {
+        new UniqueAssertionIdValidatorAction($this->getLoggerMock());
+        $this->assertTrue(true);
+    }
+
+    public function test_throws_when_two_assertions_share_an_id(): void
+    {
+        $this->expectException(LightSamlContextException::class);
+        $this->expectExceptionMessage('Response contains more than one assertion with ID "ASSERT_1"');
+
+        $response = new Response();
+        $response->addAssertion((new Assertion())->setId('ASSERT_1'));
+        $response->addAssertion((new Assertion())->setId('ASSERT_1'));
+
+        (new UniqueAssertionIdValidatorAction($this->getLoggerMock()))->execute($this->context($response));
+    }
+
+    public function test_accepts_multiple_assertions_with_distinct_ids(): void
+    {
+        $response = new Response();
+        $response->addAssertion((new Assertion())->setId('ASSERT_1'));
+        $response->addAssertion((new Assertion())->setId('ASSERT_2'));
+
+        (new UniqueAssertionIdValidatorAction($this->getLoggerMock()))->execute($this->context($response));
+
+        $this->assertTrue(true);
+    }
+
+    public function test_accepts_single_assertion(): void
+    {
+        $response = new Response();
+        $response->addAssertion((new Assertion())->setId('ASSERT_1'));
+
+        (new UniqueAssertionIdValidatorAction($this->getLoggerMock()))->execute($this->context($response));
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Action/Profile/Inbound/Response/UniqueAssertionIdValidatorActionTest.php
+++ b/tests/Action/Profile/Inbound/Response/UniqueAssertionIdValidatorActionTest.php
@@ -1,7 +1,5 @@
 <?php
 
-// tests/Action/Profile/Inbound/Response/UniqueAssertionIdValidatorActionTest.php
-
 namespace Tests\Action\Profile\Inbound\Response;
 
 use LightSaml\Action\Profile\Inbound\Response\UniqueAssertionIdValidatorAction;


### PR DESCRIPTION
# Reject Responses with duplicate assertion IDs (strict-parsing hygiene)

## Summary

A `<saml:Assertion>` `ID` is an `xsd:ID` and MUST be unique within a document, so a Response carrying two assertions with the same `ID` is malformed. lightsaml currently accepts such a Response on chains that don't validate assertion signatures. This PR adds a small, stateless check that rejects it early with a clear error.

On the default SP chain a duplicate-ID Response is already rejected (see below), and on chains that skip signature validation the duplicate confers nothing an attacker couldn't achieve with a single well-formed assertion. The value here is purely rejecting malformed input with a clear error instead of processing it silently.

## Overlap with the XSW guard (`230e62d`, #113)

Commit `230e62d` already rejects duplicate-ID documents **as a side effect ofsignature validation**: the check runs during `SignatureXmlReader::validate()` (in its private `assertNoXmlSignatureWrapping()` helper) and counts the elements carrying the ID a validated signature's `Reference` points at. On the default SP chain, where every assertion signature is validated with `requireSignature = true`, a duplicate-ID Response is therefore already rejected, and this check is redundant.

This PR just makes the underlying `xsd:ID`-uniqueness rule explicit and unconditional: it runs regardless of whether signatures are validated and covers every assertion ID in the document, not only the one a signature references.

## Proposed change

A response-level validator, registered right after `HasAssertionsValidatorAction`:

```php
<?php
// src/Action/Profile/Inbound/Response/UniqueAssertionIdValidatorAction.php

namespace LightSaml\Action\Profile\Inbound\Response;

use LightSaml\Action\Profile\AbstractProfileAction;
use LightSaml\Context\Profile\Helper\LogHelper;
use LightSaml\Context\Profile\Helper\MessageContextHelper;
use LightSaml\Context\Profile\ProfileContext;
use LightSaml\Error\LightSamlContextException;

/**
 * Rejects an inbound Response that contains more than one assertion sharing the
 * same ID. An assertion ID is an xsd:ID and MUST be unique within a document, so
 * a Response that reuses one is malformed. This is a stateless, per-document
 * check.
 */
class UniqueAssertionIdValidatorAction extends AbstractProfileAction
{
    protected function doExecute(ProfileContext $context): void
    {
        $response = MessageContextHelper::asResponse($context->getInboundContext());

        $seen = [];
        foreach ($response->getAllAssertions() as $assertion) {
            $id = $assertion->getId();
            if ($id === null || $id === '') {
                continue;
            }
            if (isset($seen[$id])) {
                $message = sprintf('Response contains more than one assertion with ID "%s"', $id);
                $this->logger->error($message, LogHelper::getActionErrorContext($context, $this));

                throw new LightSamlContextException($context, $message);
            }
            $seen[$id] = true;
        }
    }
}
```

`SsoSpReceiveResponseActionBuilder` registers the action so it runs on every inbound Response.

```php
// src/Builder/Action/Profile/SingleSignOn/Sp/SsoSpReceiveResponseActionBuilder.php

use LightSaml\Action\Profile\Inbound\Response\UniqueAssertionIdValidatorAction;

// ...

$this->add(new HasAssertionsValidatorAction(
    $this->buildContainer->getSystemContainer()->getLogger()
));
$this->add(new UniqueAssertionIdValidatorAction(
    $this->buildContainer->getSystemContainer()->getLogger()
));
```

## Tests

- Two assertions sharing one ID should be rejected (new).
- Two assertions with **distinct** IDs should still be accepted (only duplicate IDs are
  forbidden, not multiple assertions).
- Single-assertion Responses are unaffected.

```php
<?php
// tests/Action/Profile/Inbound/Response/UniqueAssertionIdValidatorActionTest.php

namespace Tests\Action\Profile\Inbound\Response;

use LightSaml\Action\Profile\Inbound\Response\UniqueAssertionIdValidatorAction;
use LightSaml\Context\Profile\ProfileContext;
use LightSaml\Error\LightSamlContextException;
use LightSaml\Model\Assertion\Assertion;
use LightSaml\Model\Protocol\Response;
use LightSaml\Profile\Profiles;
use Tests\BaseTestCase;

class UniqueAssertionIdValidatorActionTest extends BaseTestCase
{
    private function context(Response $response): ProfileContext
    {
        $context = new ProfileContext(Profiles::SSO_SP_RECEIVE_RESPONSE, ProfileContext::ROLE_SP);
        $context->getInboundContext()->setMessage($response);

        return $context;
    }

    public function test_constructs_with_logger(): void
    {
        new UniqueAssertionIdValidatorAction($this->getLoggerMock());
        $this->assertTrue(true);
    }

    public function test_throws_when_two_assertions_share_an_id(): void
    {
        $this->expectException(LightSamlContextException::class);
        $this->expectExceptionMessage('Response contains more than one assertion with ID "ASSERT_1"');

        $response = new Response();
        $response->addAssertion((new Assertion())->setId('ASSERT_1'));
        $response->addAssertion((new Assertion())->setId('ASSERT_1'));

        (new UniqueAssertionIdValidatorAction($this->getLoggerMock()))->execute($this->context($response));
    }

    public function test_accepts_multiple_assertions_with_distinct_ids(): void
    {
        $response = new Response();
        $response->addAssertion((new Assertion())->setId('ASSERT_1'));
        $response->addAssertion((new Assertion())->setId('ASSERT_2'));

        (new UniqueAssertionIdValidatorAction($this->getLoggerMock()))->execute($this->context($response));

        $this->assertTrue(true);
    }

    public function test_accepts_single_assertion(): void
    {
        $response = new Response();
        $response->addAssertion((new Assertion())->setId('ASSERT_1'));

        (new UniqueAssertionIdValidatorAction($this->getLoggerMock()))->execute($this->context($response));

        $this->assertTrue(true);
    }
}
```