### PR TITLE
fix: throw LightSamlBindingException instead of TypeError in getBindingByRequest()

### DIFF
--- a/src/Binding/BindingFactory.php
+++ b/src/Binding/BindingFactory.php
@@ -30,6 +30,13 @@ class BindingFactory implements BindingFactoryInterface
     {
         $bindingType = $this->detectBindingType($request);
 
+        if (null === $bindingType) {
+            throw new LightSamlBindingException(sprintf(
+                "Unable to detect binding type for '%s' request: invalid method or missing SAML parameters",
+                $request->getMethod()
+            ));
+        }
+
         return $this->create($bindingType);
     }
 

--- a/tests/Binding/BindingFactoryTest.php
+++ b/tests/Binding/BindingFactoryTest.php
@@ -132,6 +132,24 @@ class BindingFactoryTest extends BaseTestCase
         $this->assertInstanceOf(HttpPostBinding::class, $factory->getBindingByRequest($request));
     }
 
+    public function test__get_binding_by_request_throws_for_undetectable_get(): void
+    {
+        $this->expectException(LightSamlBindingException::class);
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('GET', '/');
+        $bindingFactory = new BindingFactory();
+        $bindingFactory->getBindingByRequest($request);
+    }
+
+    public function test__get_binding_by_request_throws_for_invalid_method(): void
+    {
+        $this->expectException(LightSamlBindingException::class);
+        $factory = new Psr17Factory();
+        $request = $factory->createServerRequest('DELETE', '/');
+        $bindingFactory = new BindingFactory();
+        $bindingFactory->getBindingByRequest($request);
+    }
+
     public function test__create_with_event_dispatcher(): void
     {
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);


### PR DESCRIPTION
## Summary
- `BindingFactory::detectBindingType()` returns `null` when the HTTP method is invalid or required SAML parameters are missing.
- `getBindingByRequest()` passed this `null` straight to `create(string $bindingType)`, causing an uncatchable PHP `TypeError` instead of the documented `LightSamlBindingException` (`BindingFactoryInterface::create()` declares `@throws LightSamlBindingException`).
- `getBindingByRequest()` now throws a `LightSamlBindingException` with a clear message when the binding type cannot be detected, matching the interface's error contract.

Fixes #115.

## Test plan
- [x] Added `test__get_binding_by_request_throws_for_undetectable_get` (GET without SAML params)
- [x] Added `test__get_binding_by_request_throws_for_invalid_method` (DELETE request)
- [x] Full test suite passes: 798 tests, 1802 assertions (PHP 8.4)