### PR TITLE
fix: reject assertions with missing or empty ID

### DIFF
--- a/src/Action/Profile/Inbound/Response/AssertionIdRequiredValidatorAction.php
+++ b/src/Action/Profile/Inbound/Response/AssertionIdRequiredValidatorAction.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LightSaml\Action\Profile\Inbound\Response;
+
+use LightSaml\Action\Profile\AbstractProfileAction;
+use LightSaml\Context\Profile\Helper\LogHelper;
+use LightSaml\Context\Profile\Helper\MessageContextHelper;
+use LightSaml\Context\Profile\ProfileContext;
+use LightSaml\Error\LightSamlContextException;
+
+/**
+ * Rejects an inbound Response containing an assertion with a missing or empty
+ * ID. ID is a required xsd:ID attribute on saml:Assertion per the SAML schema.
+ */
+class AssertionIdRequiredValidatorAction extends AbstractProfileAction
+{
+    protected function doExecute(ProfileContext $context): void
+    {
+        $response = MessageContextHelper::asResponse($context->getInboundContext());
+
+        foreach ($response->getAllAssertions() as $assertion) {
+            $id = $assertion->getId();
+            if ($id === null || $id === '') {
+                $message = 'Response contains an assertion with a missing or empty ID';
+                $this->logger->error($message, LogHelper::getActionErrorContext($context, $this));
+
+                throw new LightSamlContextException($context, $message);
+            }
+        }
+    }
+}

--- a/src/Builder/Action/Profile/SingleSignOn/Sp/SsoSpReceiveResponseActionBuilder.php
+++ b/src/Builder/Action/Profile/SingleSignOn/Sp/SsoSpReceiveResponseActionBuilder.php
@@ -11,6 +11,7 @@ use LightSaml\Action\Profile\Inbound\Message\MessageSignatureValidatorAction;
 use LightSaml\Action\Profile\Inbound\Message\ReceiveMessageAction;
 use LightSaml\Action\Profile\Inbound\Message\ResolvePartyEntityIdAction;
 use LightSaml\Action\Profile\Inbound\Response\AssertionAction;
+use LightSaml\Action\Profile\Inbound\Response\AssertionIdRequiredValidatorAction;
 use LightSaml\Action\Profile\Inbound\Response\DecryptAssertionsAction;
 use LightSaml\Action\Profile\Inbound\Response\HasAssertionsValidatorAction;
 use LightSaml\Action\Profile\Inbound\Response\HasAuthnStatementValidatorAction;
@@ -80,6 +81,9 @@ class SsoSpReceiveResponseActionBuilder extends AbstractProfileActionBuilder
         ));
 
         $this->add(new HasAssertionsValidatorAction(
+            $this->buildContainer->getSystemContainer()->getLogger()
+        ));
+        $this->add(new AssertionIdRequiredValidatorAction(
             $this->buildContainer->getSystemContainer()->getLogger()
         ));
         $this->add(new UniqueAssertionIdValidatorAction(

--- a/tests/Action/Profile/Inbound/Response/AssertionIdRequiredValidatorActionTest.php
+++ b/tests/Action/Profile/Inbound/Response/AssertionIdRequiredValidatorActionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Action\Profile\Inbound\Response;
+
+use LightSaml\Action\Profile\Inbound\Response\AssertionIdRequiredValidatorAction;
+use LightSaml\Context\Profile\ProfileContext;
+use LightSaml\Error\LightSamlContextException;
+use LightSaml\Model\Assertion\Assertion;
+use LightSaml\Model\Protocol\Response;
+use LightSaml\Profile\Profiles;
+use Tests\BaseTestCase;
+
+class AssertionIdRequiredValidatorActionTest extends BaseTestCase
+{
+    private function context(Response $response): ProfileContext
+    {
+        $context = new ProfileContext(Profiles::SSO_SP_RECEIVE_RESPONSE, ProfileContext::ROLE_SP);
+        $context->getInboundContext()->setMessage($response);
+
+        return $context;
+    }
+
+    public function test_constructs_with_logger(): void
+    {
+        new AssertionIdRequiredValidatorAction($this->getLoggerMock());
+        $this->assertTrue(true);
+    }
+
+    public function test_throws_when_assertion_id_is_null(): void
+    {
+        $this->expectException(LightSamlContextException::class);
+        $this->expectExceptionMessage('Response contains an assertion with a missing or empty ID');
+
+        $response = new Response();
+        $response->addAssertion(new Assertion());
+
+        (new AssertionIdRequiredValidatorAction($this->getLoggerMock()))->execute($this->context($response));
+    }
+
+    public function test_throws_when_assertion_id_is_empty_string(): void
+    {
+        $this->expectException(LightSamlContextException::class);
+        $this->expectExceptionMessage('Response contains an assertion with a missing or empty ID');
+
+        $response = new Response();
+        $response->addAssertion((new Assertion())->setId(''));
+
+        (new AssertionIdRequiredValidatorAction($this->getLoggerMock()))->execute($this->context($response));
+    }
+
+    public function test_throws_when_second_assertion_id_is_missing(): void
+    {
+        $this->expectException(LightSamlContextException::class);
+        $this->expectExceptionMessage('Response contains an assertion with a missing or empty ID');
+
+        $response = new Response();
+        $response->addAssertion((new Assertion())->setId('ASSERT_1'));
+        $response->addAssertion(new Assertion());
+
+        (new AssertionIdRequiredValidatorAction($this->getLoggerMock()))->execute($this->context($response));
+    }
+
+    public function test_accepts_assertions_with_ids(): void
+    {
+        $response = new Response();
+        $response->addAssertion((new Assertion())->setId('ASSERT_1'));
+        $response->addAssertion((new Assertion())->setId('ASSERT_2'));
+
+        (new AssertionIdRequiredValidatorAction($this->getLoggerMock()))->execute($this->context($response));
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AssertionIdRequiredValidatorAction`, rejecting any inbound Response containing an assertion with a missing or empty `ID`
- Wire it into `SsoSpReceiveResponseActionBuilder` right before `UniqueAssertionIdValidatorAction`, so missing IDs are caught before the duplicate-ID check can be bypassed
- Add tests covering null ID, empty-string ID, a second assertion with missing ID, and the happy path

Fixes #117

## Test plan
- [x] `vendor/bin/phpunit` — full suite green (803 tests)
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/php-cs-fixer check` — clean